### PR TITLE
Refresh black theme to luxury deep green palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
         :root {
             --gold: #d4af37;
             --gold-light: #f1d592;
-            --dark: #050505;
-            --dark-soft: #0f0f0f;
+            --dark: #062b1f;
+            --dark-soft: #0c3a2b;
             --card-bg: rgba(255, 255, 255, 0.02);
             --glass: rgba(255, 255, 255, 0.05);
             --transition: all 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275);
@@ -61,7 +61,7 @@
             position: fixed; top: 0; width: 100%;
             padding: 25px 10%; z-index: 1000;
             display: flex; justify-content: space-between; align-items: center;
-            background: rgba(5, 5, 5, 0.85); backdrop-filter: blur(15px);
+            background: rgba(6, 43, 31, 0.85); backdrop-filter: blur(15px);
             border-bottom: 1px solid rgba(212, 175, 55, 0.1);
         }
         .logo {
@@ -157,7 +157,7 @@
 
         /* --- التذييل --- */
         footer {
-            background: #020202; padding: 80px 10% 40px;
+            background: #041d15; padding: 80px 10% 40px;
             border-top: 1px solid rgba(212,175,55,0.1);
             display: flex; flex-direction: column; align-items: center;
         }


### PR DESCRIPTION
### Motivation
- Replace the site's near‑black base with a dark green luxury palette so the UI reads as a premium, digital brand while preserving gold accents.

### Description
- Updated color variables and backgrounds in `index.html` by replacing `--dark` and `--dark-soft` with deep green values and adjusting the header overlay and footer background to match the new palette.

### Testing
- Ran `git diff -- index.html` to inspect the CSS delta and verify the color updates; the diff shows the intended replacements and succeeded. 
- Attempted an automated visual capture using Playwright after starting a local `python3 -m http.server`, but the Chromium run failed with a SIGSEGV in this environment, so screenshot generation did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a57a94363483309051b98406af95a5)